### PR TITLE
Fix broken tests with latest version of mock

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -31,7 +31,9 @@ class TestKarmaPlugin(TestCase):
             to_user = mock.Mock()
             db.get_for_nick.side_effect = [from_user, to_user]
 
-            from_user.give_karma_to.assertCalledWith(to_user)
+            self.plugin.give('foo', 'bar')
+
+            from_user.give_karma_to.assert_called_with(to_user)
 
     def test_top(self):
         with mock.patch.object(self.plugin, 'KarmaRecord') as db:
@@ -104,7 +106,7 @@ class TestKarmaPlugin(TestCase):
             db.get_for_nick.side_effect = [user1, user2]
 
             self.plugin.alias('me', 'foo', 'bar')
-            user2.add_alias.assertCalledWith(user1)
+            user2.add_alias.assert_called_with(user1)
 
     def test_alias(self):
         with mock.patch.object(self.plugin, 'KarmaRecord') as db:
@@ -118,7 +120,7 @@ class TestKarmaPlugin(TestCase):
             db.get_for_nick.side_effect = [user1, user2]
 
             self.plugin.alias('me', 'foo', 'bar')
-            user1.add_alias.assertCalledWith(user2)
+            user1.add_alias.assert_called_with(user2)
 
     def test_unalias_nope_with_same_nick(self):
         with mock.patch.object(self.plugin, 'KarmaRecord') as db:
@@ -150,14 +152,15 @@ class TestKarmaPlugin(TestCase):
 
     def test_unalias(self):
         with mock.patch.object(self.plugin, 'KarmaRecord') as db:
-            user1 = mock.Mock()
             user2 = mock.Mock()
 
             user2.get_aliases.return_value = ['bar']
 
             db.get_for_nick.side_effect = [None, user2]
 
-            user2.remove_alias.assertCalledWith(user1)
+            self.plugin.unalias(requested_by='me', nick1='bar', nick2='foo')
+
+            user2.remove_alias.assert_called_with('bar')
 
     @mock.patch('helga_karma.plugin.settings')
     def test_message_overrides(self, settings):


### PR DESCRIPTION
This should fix #16. It seems like the main failure was supporting the latest version of mock. I had to fix a couple of broken tests when switching to `assert_called_with`