### PR TITLE
support adding karma to nicks with `++`

### DIFF
--- a/helga_karma/data.py
+++ b/helga_karma/data.py
@@ -18,8 +18,9 @@ class KarmaRecord(object):
 
     @classmethod
     def get_actual_nick(cls, nick):
-        if nick.find('|'):
-            nick = nick.split('|')[0]
+        nick = nick.split('|')[0]
+        if nick.endswith('++'):
+            nick = nick.split('+')[0]
         record = db.karma_link.find_one(
             {'nick': nick}
         )

--- a/helga_karma/plugin.py
+++ b/helga_karma/plugin.py
@@ -256,8 +256,8 @@ def _autokarma_match(message):
         thanks='|'.join(thanks_words),
         nick=VALID_NICK_PAT
     )
-
-    return re.findall(pattern, message)
+    pp_pattern = r'(\w*\s+)*({nick})\+\+(\s+|$).*$'.format(nick=VALID_NICK_PAT)
+    return re.findall(pattern, message) or re.findall(pp_pattern, message)
 
 
 @match(_autokarma_match)

--- a/helga_karma/plugin.py
+++ b/helga_karma/plugin.py
@@ -56,6 +56,12 @@ _DEFAULT_THANKS_WORDS = [
     'ty',
 ]
 
+_DEFAULT_INVALID_WORDS = [
+    'i',
+    'for',
+]
+
+
 
 def format_message(name, **kwargs):
     overrides = getattr(settings, 'KARMA_MESSAGE_OVERRIDES', {})
@@ -248,9 +254,20 @@ def _autokarma_match(message):
     """
     Match an incoming message for any nicks that should receive auto karma
     """
+    invalid_thanks = getattr(settings,
+                             'KARMA_INVALID_THANKS',
+                             _DEFAULT_INVALID_WORDS)
+
     thanks_words = getattr(settings,
                            'KARMA_THANKS_WORDS',
                            _DEFAULT_THANKS_WORDS)
+
+    skip_pattern = r'^(?i)({thanks})\s+({invalid}).*$'.format(
+        thanks='|'.join(thanks_words),
+        invalid='|'.join(invalid_thanks),
+    )
+    if re.findall(skip_pattern, message):
+        return None
 
     pattern = r'^(?i)({thanks})[^\w]+({nick}).*$'.format(
         thanks='|'.join(thanks_words),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -63,6 +63,14 @@ class TestKarmaRecord(TestCase):
 
         self.assertEqual(actual_result, expected_result)
 
+    def test_get_nick_with_plus_plus(self):
+        arbitrary_nick = 'somebody++'
+
+        k = self.KarmaRecord({})
+        result = k.get_actual_nick(arbitrary_nick)
+
+        self.assertEqual(result, 'somebody')
+
     def test_get_actual_nick_no_alias(self):
         arbitrary_nick = 'two'
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -188,3 +188,26 @@ class TestKarmaPlugin(TestCase):
         assert 'helga' == matcher('ty helga. i needed that reminder')[0][1]
 
         assert not matcher('i appreciate it helga')
+
+
+class TestPlusPlusSupport(TestKarmaPlugin):
+
+    def test_autokarma_match_nick_alone(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher('helga++')[0][1]
+
+    def test_autokarma_match_nick_leading_whitespace(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher(' helga++')[0][1]
+
+    def test_autokarma_match_leading_text_matches(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher('you are doing great helga++')[0][1]
+
+    def test_autokarma_match_trailing_text_matches(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher('you are doing great helga++ fantastic job there')[0][1]
+
+    def test_autokarma_no_match_trailing_garbage(self):
+        matcher = self.plugin._autokarma_match
+        assert matcher('helga++burrrr') is None

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -210,4 +210,16 @@ class TestPlusPlusSupport(TestKarmaPlugin):
 
     def test_autokarma_no_match_trailing_garbage(self):
         matcher = self.plugin._autokarma_match
-        assert matcher('helga++burrrr') is None
+        assert matcher('helga++burrrr') == []
+
+
+class TestInvalidWords(TestKarmaPlugin):
+    # if py.test fixtures get used, they should be in place for these
+    # tests to get all combinations of `thanks` that the plugin supports
+    def test_default_for_does_not_match(self):
+        matcher = self.plugin._autokarma_match
+        assert matcher('thanks for helping out') is None
+
+    def test_default_i_does_not_match(self):
+        matcher = self.plugin._autokarma_match
+        assert matcher('thanks I was able to fix it') is None


### PR DESCRIPTION
I didn't make it optional, but don't think this should be an option since it is *very* common for users to do:

    alfredo> helga++

To give karma to another user. If that is not OK I can fit the option in, either way would love to get this in.

