### PR TITLE
ports all tests to py.test

### DIFF
--- a/helga_karma/data.py
+++ b/helga_karma/data.py
@@ -18,8 +18,9 @@ class KarmaRecord(object):
 
     @classmethod
     def get_actual_nick(cls, nick):
-        if nick.find('|'):
-            nick = nick.split('|')[0]
+        nick = nick.split('|')[0]
+        if nick.endswith('++'):
+            nick = nick.split('+')[0]
         record = db.karma_link.find_one(
             {'nick': nick}
         )

--- a/helga_karma/plugin.py
+++ b/helga_karma/plugin.py
@@ -256,8 +256,8 @@ def _autokarma_match(message):
         thanks='|'.join(thanks_words),
         nick=VALID_NICK_PAT
     )
-
-    return re.findall(pattern, message)
+    pp_pattern = r'(\w*\s+)*({nick})\+\+(\s+|$).*$'.format(nick=VALID_NICK_PAT)
+    return re.findall(pattern, message) or re.findall(pp_pattern, message)
 
 
 @match(_autokarma_match)

--- a/helga_karma/plugin.py
+++ b/helga_karma/plugin.py
@@ -244,10 +244,13 @@ def _handle_command(client, channel, nick, message, command, args):
 
 
 def _handle_match(client, channel, nick, message, matches):
-    to_nick = matches[0][1]
+    is_pp = matches[0][1].endswith('++')
+    to_nick = matches[0][1].split('++')[0]
     logger.info('Autokarma: {from_nick} -> {to_nick}'.format(from_nick=nick,
                                                              to_nick=to_nick))
-    give(from_nick=nick, to_nick=to_nick)
+    karma_given = give(from_nick=nick, to_nick=to_nick)
+    if is_pp:
+        return karma_given
 
 
 def _autokarma_match(message):
@@ -273,7 +276,7 @@ def _autokarma_match(message):
         thanks='|'.join(thanks_words),
         nick=VALID_NICK_PAT
     )
-    pp_pattern = r'(\w*\s+)*({nick})\+\+(\s+|$).*$'.format(nick=VALID_NICK_PAT)
+    pp_pattern = r'(\w*\s+)*({nick}\+\+)(\s+|$).*$'.format(nick=VALID_NICK_PAT)
     return re.findall(pattern, message) or re.findall(pp_pattern, message)
 
 

--- a/helga_karma/plugin.py
+++ b/helga_karma/plugin.py
@@ -56,6 +56,12 @@ _DEFAULT_THANKS_WORDS = [
     'ty',
 ]
 
+_DEFAULT_INVALID_WORDS = [
+    'i',
+    'for',
+]
+
+
 
 def format_message(name, **kwargs):
     overrides = getattr(settings, 'KARMA_MESSAGE_OVERRIDES', {})
@@ -248,9 +254,20 @@ def _autokarma_match(message):
     """
     Match an incoming message for any nicks that should receive auto karma
     """
+    invalid_thanks = getattr(settings,
+                             'KARMA_INVALID_THANKS',
+                             _DEFAULT_INVALID_WORDS)
+
     thanks_words = getattr(settings,
                            'KARMA_THANKS_WORDS',
                            _DEFAULT_THANKS_WORDS)
+
+    skip_pattern = r'^(?i)({thanks})\s+({invalid}).*$'.format(
+        thanks='|'.join(thanks_words),
+        invalid='|'.join(invalid_thanks),
+    )
+    if re.findall(skip_pattern, message):
+        return None
 
     pattern = r'^(?i)({thanks})[^\w]+({nick}).*$'.format(
         thanks='|'.join(thanks_words),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -63,6 +63,14 @@ class TestKarmaRecord(TestCase):
 
         self.assertEqual(actual_result, expected_result)
 
+    def test_get_nick_with_plus_plus(self):
+        arbitrary_nick = 'somebody++'
+
+        k = self.KarmaRecord({})
+        result = k.get_actual_nick(arbitrary_nick)
+
+        self.assertEqual(result, 'somebody')
+
     def test_get_actual_nick_no_alias(self):
         arbitrary_nick = 'two'
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,5 @@
 import datetime
 import math
-from unittest import TestCase
 
 import mock
 import mongomock
@@ -10,16 +9,12 @@ import mongomock
 #from helga_karma.data import KarmaRecord
 
 
-class TestKarmaRecord(TestCase):
-    def setUp(self):
-        super(TestKarmaRecord, self).setUp()
+class TestKarmaRecord(object):
 
-        self.db_patch = mock.patch(
-            'pymongo.MongoClient',
-            new_callable=lambda: mongomock.Connection
-        )
-        self.db_patch.start()
-        self.addCleanup(self.db_patch.stop)
+    def setup(self):
+        from _pytest.monkeypatch import monkeypatch
+        patch = monkeypatch()
+        patch.setattr('pymongo.MongoClient', mongomock.Connection)
 
         from helga_karma.data import KarmaRecord
         from helga.db import db
@@ -33,7 +28,7 @@ class TestKarmaRecord(TestCase):
         record.save()
         return record
 
-    def tearDown(self):
+    def teardown(self):
         self.db.karma_user.drop()
         self.db.karma_link.drop()
 
@@ -52,7 +47,7 @@ class TestKarmaRecord(TestCase):
         actual_result = k.get_actual_nick(arbitrary_alias)
         expected_result = arbitrary_nick
 
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result
 
     def test_get_nick_with_pipe(self):
         arbitrary_nick = 'somebody|away'
@@ -61,7 +56,7 @@ class TestKarmaRecord(TestCase):
         actual_result = k.get_actual_nick(arbitrary_nick)
         expected_result = arbitrary_nick.split('|')[0]
 
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result
 
     def test_get_nick_with_plus_plus(self):
         arbitrary_nick = 'somebody++'
@@ -69,7 +64,7 @@ class TestKarmaRecord(TestCase):
         k = self.KarmaRecord({})
         result = k.get_actual_nick(arbitrary_nick)
 
-        self.assertEqual(result, 'somebody')
+        assert result == 'somebody'
 
     def test_get_actual_nick_no_alias(self):
         arbitrary_nick = 'two'
@@ -78,7 +73,7 @@ class TestKarmaRecord(TestCase):
         actual_result = k.get_actual_nick(arbitrary_nick)
         expected_result = arbitrary_nick
 
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result
 
     def test_get_for_nick_existing(self):
         existing_nick = 'alpha'
@@ -90,15 +85,12 @@ class TestKarmaRecord(TestCase):
         self.db.karma_user.insert(arbitrary_record)
 
         k = self.KarmaRecord.get_for_nick(existing_nick)
-        self.assertEqual(
-            k['given'],
-            arbitrary_given,
-        )
+        assert k['given'] == arbitrary_given
 
     def test_get_for_nick_new(self):
         non_existing_nick = 'beta'
         k = self.KarmaRecord.get_for_nick(non_existing_nick)
-        self.assertEqual(k['given'], 0)
+        assert k['given'] == 0
 
     def test_get_top(self):
         first = {'nick': 'three', 'value': 15.0}
@@ -109,9 +101,9 @@ class TestKarmaRecord(TestCase):
         self.db.karma_user.insert(first)
 
         expected_results = list(self.KarmaRecord.get_top(limit=2))
-        self.assertEquals(expected_results[0]['nick'], first['nick'])
-        self.assertEquals(expected_results[1]['nick'], second['nick'])
-        self.assertEquals(len(expected_results), 2)
+        assert expected_results[0]['nick'] == first['nick']
+        assert expected_results[1]['nick'] == second['nick']
+        assert len(expected_results) == 2
 
     def test_add_alias(self):
         main_nick = 'one'
@@ -134,10 +126,10 @@ class TestKarmaRecord(TestCase):
 
         actual_result = self.KarmaRecord.get_for_nick(alias_nick)
 
-        self.assertEquals(actual_result['nick'], main_nick)
-        self.assertEquals(actual_result['value'], 20)
-        self.assertEquals(actual_result['given'], 20)
-        self.assertEquals(actual_result['received'], 20)
+        assert actual_result['nick'] == main_nick
+        assert actual_result['value'] == 20
+        assert actual_result['given'] == 20
+        assert actual_result['received'] == 20
 
     def test_remove_alias(self):
         main_nick = 'three'
@@ -170,10 +162,10 @@ class TestKarmaRecord(TestCase):
         main_record = self.KarmaRecord.get_for_nick(main_nick)
         alias_record = self.KarmaRecord.get_for_nick(alias_nick)
 
-        self.assertEquals(main_record['nick'], main_nick)
-        self.assertEquals(main_record['value'], 10)
-        self.assertEquals(alias_record['nick'], alias_nick)
-        self.assertEquals(alias_record['value'], 10)
+        assert main_record['nick'] == main_nick
+        assert main_record['value'] == 10
+        assert alias_record['nick'] == alias_nick
+        assert alias_record['value'] == 10
 
     def test_get_aliases(self):
         main_nick = 'beta'
@@ -189,7 +181,7 @@ class TestKarmaRecord(TestCase):
         actual_results = set(main_record.get_aliases())
         expected_results = set([alias_nick1, alias_nick2])
 
-        self.assertEquals(actual_results, expected_results)
+        assert actual_results == expected_results
 
     @mock.patch('helga_karma.data.KarmaRecord.get_coefficient')
     def test_give_karma_to(self, get_coefficient_mock):
@@ -214,9 +206,9 @@ class TestKarmaRecord(TestCase):
 
         from_record.give_karma_to(to_record)
 
-        self.assertEquals(from_record['given'], 11)
-        self.assertEquals(to_record['received'], 11)
-        self.assertEquals(to_record['value'], 11)
+        assert from_record['given'] == 11
+        assert to_record['received'] == 11
+        assert to_record['value'] == 11
 
     def test_get_global_karma_maximum(self):
         maximum_value = 30
@@ -230,7 +222,7 @@ class TestKarmaRecord(TestCase):
         expected_value = maximum_value
         actual_value = self.KarmaRecord.get_global_karma_maximum()
 
-        self.assertEqual(actual_value, expected_value)
+        assert actual_value == expected_value
 
     def test_get_value_unscaled(self):
         karma_value = 223.210
@@ -239,7 +231,7 @@ class TestKarmaRecord(TestCase):
         expected_result = karma_value
         actual_result = record.get_value()
 
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result
 
     @mock.patch('helga_karma.data.settings')
     def test_get_value_scaled_linear(self, settings):
@@ -261,7 +253,7 @@ class TestKarmaRecord(TestCase):
         )
         actual_result = user.get_value()
 
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result
 
     @mock.patch('helga_karma.data.settings')
     def test_get_value_scaled(self, settings):
@@ -283,4 +275,4 @@ class TestKarmaRecord(TestCase):
         )
         actual_result = user.get_value()
 
-        self.assertEqual(actual_result, expected_result)
+        assert actual_result == expected_result

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -26,6 +26,8 @@ class TestKarmaPlugin(object):
             to_user = mock.Mock()
             db.get_for_nick.side_effect = [from_user, to_user]
 
+            self.plugin.give('foo', 'bar')
+
             from_user.give_karma_to.assert_called_with(to_user)
 
     def test_top(self):
@@ -145,14 +147,15 @@ class TestKarmaPlugin(object):
 
     def test_unalias(self):
         with mock.patch.object(self.plugin, 'KarmaRecord') as db:
-            user1 = mock.Mock()
             user2 = mock.Mock()
 
             user2.get_aliases.return_value = ['bar']
 
             db.get_for_nick.side_effect = [None, user2]
 
-            user2.remove_alias.assert_called_with(user1)
+            self.plugin.unalias(requested_by='me', nick1='bar', nick2='foo')
+
+            user2.remove_alias.assert_called_with('bar')
 
     @mock.patch('helga_karma.plugin.settings')
     def test_message_not_overridden(self, settings):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -201,19 +201,19 @@ class TestPlusPlusSupport(TestKarmaPlugin):
 
     def test_autokarma_match_nick_alone(self):
         matcher = self.plugin._autokarma_match
-        assert 'helga' == matcher('helga++')[0][1]
+        assert 'helga++' == matcher('helga++')[0][1]
 
     def test_autokarma_match_nick_leading_whitespace(self):
         matcher = self.plugin._autokarma_match
-        assert 'helga' == matcher(' helga++')[0][1]
+        assert 'helga++' == matcher(' helga++')[0][1]
 
     def test_autokarma_match_leading_text_matches(self):
         matcher = self.plugin._autokarma_match
-        assert 'helga' == matcher('you are doing great helga++')[0][1]
+        assert 'helga++' == matcher('you are doing great helga++')[0][1]
 
     def test_autokarma_match_trailing_text_matches(self):
         matcher = self.plugin._autokarma_match
-        assert 'helga' == matcher('you are doing great helga++ fantastic job there')[0][1]
+        assert 'helga++' == matcher('you are doing great helga++ fantastic job there')[0][1]
 
     def test_autokarma_no_match_trailing_garbage(self):
         matcher = self.plugin._autokarma_match

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -188,3 +188,26 @@ class TestKarmaPlugin(TestCase):
         assert 'helga' == matcher('ty helga. i needed that reminder')[0][1]
 
         assert not matcher('i appreciate it helga')
+
+
+class TestPlusPlusSupport(TestKarmaPlugin):
+
+    def test_autokarma_match_nick_alone(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher('helga++')[0][1]
+
+    def test_autokarma_match_nick_leading_whitespace(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher(' helga++')[0][1]
+
+    def test_autokarma_match_leading_text_matches(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher('you are doing great helga++')[0][1]
+
+    def test_autokarma_match_trailing_text_matches(self):
+        matcher = self.plugin._autokarma_match
+        assert 'helga' == matcher('you are doing great helga++ fantastic job there')[0][1]
+
+    def test_autokarma_no_match_trailing_garbage(self):
+        matcher = self.plugin._autokarma_match
+        assert matcher('helga++burrrr') is None

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -210,4 +210,16 @@ class TestPlusPlusSupport(TestKarmaPlugin):
 
     def test_autokarma_no_match_trailing_garbage(self):
         matcher = self.plugin._autokarma_match
-        assert matcher('helga++burrrr') is None
+        assert matcher('helga++burrrr') == []
+
+
+class TestInvalidWords(TestKarmaPlugin):
+    # if py.test fixtures get used, they should be in place for these
+    # tests to get all combinations of `thanks` that the plugin supports
+    def test_default_for_does_not_match(self):
+        matcher = self.plugin._autokarma_match
+        assert matcher('thanks for helping out') is None
+
+    def test_default_i_does_not_match(self):
+        matcher = self.plugin._autokarma_match
+        assert matcher('thanks I was able to fix it') is None


### PR DESCRIPTION
And cherry-picks @shaunduncan work to fix the broken ones from an older version of Mock.

I do realize this may seem a bit rude, but there was already a mix of TestCase and py.test work (from test_data.py and test_plugin.py) so this helps normalize everything.

This PR is built on top of PR #18 and PR #19 